### PR TITLE
Added Google_checks Checkstyle with custom supression script and other integrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
 - mvn site
+ls
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: 
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
+- mvn pmd
 - mvn site
 - cd environment/target
 - ls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
 - mvn site
-- cd environment/reports
+- cd environment
 - ls
 - cat pmd-report.txt
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: 
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
-- mvn pmd
+- mvn pmd:pmd
 - mvn site
 - cd environment
 - ls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: 
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
+- maven pmd
 - mvn test
-- maven pmd xdoc
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: 
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
-- mvn pmd
+- mvn site
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: 
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
-- maven pmd
 - mvn test
+- mvn pmd
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
 - mvn site
-- cd target/site
 - ls
+- ls reports/
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,16 @@
-sudo: required
-dist: trusty
 language: java
-before_install: 
-- echo -ne '\n' | sudo add-apt-repository ppa:fkrull/deadsnakes
-- sudo apt-get update
-- sudo apt-get install python2.7
-# https://stackoverflow.com/questions/12076326/how-to-install-maven2-on-redhat-linux
-- wget http://mirror.olnevhost.net/pub/apache/maven/binaries/apache-maven-3.2.1-bin.tar.gz
-- tar xvf apache-maven-3.2.1-bin.tar.gz
-- export M3_HOME=/usr/local/apache-maven/apache-maven-3.2.1
-- export M3=$M3_HOME/bin
-- export PATH=$M3:$PATH
-- mvn -version
-install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -X
+before_install:
+# download jython to use the python scripts for checkstyle
+- wget http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/2.7.0/jython-standalone-2.7.0.jar -O jython-standalone-2.7.0.jar
+install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script:
-# test the code
+- ls
+# test checkstyle only on changed lines using this python script
+- git diff | java -jar jython-standalone-2.7.0.jar checkstylediff.py
+# add login credentials in registry
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
+# test the code
 - mvn test
-# test checkstyle only on changed lines
-- git diff | python checkstylediff.py
 - mvn checkstyle:checkstyle
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ before_install:
 # download jython to use the python scripts for checkstyle
 - wget http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/2.7.0/jython-standalone-2.7.0.jar -O jython-standalone-2.7.0.jar
 install: 
-- mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+- mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -Dcobertura.skip -B -V 
 script:
 # add login credentials in registry
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 # test the code
-- mvn test
+- mvn test -Dcobertura.skip
 # test checkstyle only on changed lines using this python script
 - git diff master HEAD | java -jar jython-standalone-2.7.0.jar checkstylediff.py
 - mvn checkstyle:checkstyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,15 @@ install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: 
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
-- mvn pmd:pmd
-- mvn site
+#check pmd only for environment
 - cd environment
-- ls
+- mvn pmd:pmd
+- cd target
+- echo "PMD-Results"
+- cat java-basic.xml
+- cat java-imports.xml
+- cat java-unusedcode.xml
+- echo "PMD-Results END"
+- cd ../..
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
 - mvn site
-- cd target
+- cd target/site
 - ls
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: java
 before_install:
 # download jython to use the python scripts for checkstyle
 - wget http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/2.7.0/jython-standalone-2.7.0.jar -O jython-standalone-2.7.0.jar
-install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+install: 
+- mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script:
-- ls
-# test checkstyle only on changed lines using this python script
-- git diff | java -jar jython-standalone-2.7.0.jar checkstylediff.py
 # add login credentials in registry
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 # test the code
 - mvn test
+# test checkstyle only on changed lines using this python script
+- git diff | java -jar jython-standalone-2.7.0.jar checkstylediff.py
 - mvn checkstyle:checkstyle
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ script:
 #check pmd only for environment
 - cd environment
 - mvn pmd:pmd
+- mvn findbugs:findbugs
 - cd target
-- echo "PMD-Results"
-- cat java-basic.xml
-- cat java-imports.xml
-- cat java-unusedcode.xml
-- echo "PMD-Results END"
+- echo "*PMD-Results*" && cat "java-basic.xml" && cat "java-imports.xml" && cat "java-unusedcode.xml" && echo "PMD-Results END"
+- echo "*FINDBUGS-Results*" && cat "findbugsXml.xml" && echo "FINDBUGS-Results END"
 - cd ../..
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+dist: trusty
+language: java
+before_install: 
+- echo -ne '\n' | sudo add-apt-repository ppa:fkrull/deadsnakes
+- sudo apt-get update
+- sudo apt-get install python2.7
+# https://stackoverflow.com/questions/12076326/how-to-install-maven2-on-redhat-linux
+- wget http://mirror.olnevhost.net/pub/apache/maven/binaries/apache-maven-3.2.1-bin.tar.gz
+- tar xvf apache-maven-3.2.1-bin.tar.gz
+- export M3_HOME=/usr/local/apache-maven/apache-maven-3.2.1
+- export M3=$M3_HOME/bin
+- export PATH=$M3:$PATH
+- mvn -version
+install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -X
+script:
+# test the code
+- java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
+- mvn test
+# test checkstyle only on changed lines
+- git diff | python checkstylediff.py
+- mvn checkstyle:checkstyle
+jdk:
+- oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
 - mvn site
+- cd environment/reports
 - ls
-- ls reports/
+- cat pmd-report.txt
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 # test the code
 - mvn test
 # test checkstyle only on changed lines using this python script
-- git diff | java -jar jython-standalone-2.7.0.jar checkstylediff.py
+- git diff master HEAD | java -jar jython-standalone-2.7.0.jar checkstylediff.py
 - mvn checkstyle:checkstyle
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script:
 - mvn test
 - mvn pmd
 - mvn site
-- cd environment/target
+- cd environment
 - ls
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
 - mvn site
+- cd target
 - ls
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+install: mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+script: 
+- java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
+- mvn test
+- maven pmd xdoc
+jdk:
+- oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
 - mvn site
-- cd environment
+- cd environment/target
 - ls
-- cat pmd-report.txt
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ script:
 - java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - mvn test
 - mvn site
-ls
+- ls
 jdk:
 - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,8 @@ script:
 # test checkstyle only on changed lines using this python script
 - git diff master HEAD | java -jar jython-standalone-2.7.0.jar checkstylediff.py
 - mvn checkstyle:checkstyle
+# run cobertura only in environment build fails when coverage is too low
+- cd environment
+- mvn cobertura:check
 jdk:
 - oraclejdk8

--- a/checkstylediff.py
+++ b/checkstylediff.py
@@ -1,0 +1,77 @@
+import sys
+import re
+import os
+import fileinput
+
+MAX_LINE_AMOUNT = 20000;
+
+outputfile = "suppression.xml"
+
+info = "<?xml version="+'"'+"1.0"+'"'+"?><!DOCTYPE suppressions PUBLIC"+'"-//Puppy Crawl//DTD Suppressions 1.1//EN"'+'"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd"'+">"
+
+start = "<suppression>"
+changed_files = []
+currentfile = ""
+changes_in_file = []
+
+# This function takes the filename and the changes as a list of lists and prints the suppression for that file.
+def suppressfile(file, changes):
+	supressed_lines = range(1, MAX_LINE_AMOUNT)
+	start = "<suppress checks="+'"'+".*"+'"'
+	files = "files="+file
+	lines = ""
+	if changes:
+		print(changes)
+		for i in changes:
+			lines_to_check = range(i[0], i[0]+i[1])
+			supressed_lines = [x for x in supressed_lines if x not in lines_to_check]
+		segments = []
+		segment = (supressed_lines[0],supressed_lines[0])
+		pos = 0
+		for i in supressed_lines:
+			if len(supressed_lines) <= pos + 1:
+				segments.append((segment[0], MAX_LINE_AMOUNT))
+			elif i + 1 == supressed_lines[pos + 1]:
+				segment = (segment[0], i+1)
+			else: 
+				segments.append(segment)
+				segment = (supressed_lines[pos + 1],supressed_lines[pos + 1])
+			pos = pos + 1
+				
+		#lines = ""
+		for i in segments:
+			lines += str(i[0])+"-"+str(i[1])+" "
+		lines = 'lines="'+lines+'"'
+	return start +" "+ files +" "+ lines +"/>"
+	
+
+for line in sys.stdin:
+	if re.findall("diff --git", line):
+		if not currentfile:
+			currentfile = re.findall("\sb/.*\s", line)[0].replace(" b/","").replace(" ","").replace("\n","")
+		newfile = re.findall("\sb/.*\s", line)[0].replace(" b/","").replace(" ","").replace("\n","")
+		if(newfile != currentfile):
+			changed_files.append((currentfile, changes_in_file))
+			changes_in_file = []
+		currentfile = newfile
+	elif re.findall("@@\s.*\s@@",line):
+		changed = re.findall("\+.*\s", re.findall("@@\s.*\s@@",line)[0])[0]
+		changes_in_file.append([int(x) for x in changed.replace("+","").split(",")])
+		
+changed_files.append((currentfile,changes_in_file))
+
+
+java_files = []
+for root, dirs, files in os.walk("./"):
+	for file in files:
+		if file.endswith(".java"):
+			java_files.append(os.path.join(root, file))
+java_files = [x.replace("./","").replace("\\","/") for x in java_files]
+suppressed_files = [(file,False) for file in [y for y in java_files] if not(file in [y[0] for y in changed_files])]
+changed_files.extend(suppressed_files)
+
+content = "".join([suppressfile(x[0],x[1])+"\n" for x in changed_files])
+		
+end = "</suppression>"
+open(outputfile, "w").write(info+"\n"+start+"\n"+content+end)
+

--- a/checkstylediff.py
+++ b/checkstylediff.py
@@ -8,6 +8,8 @@ import re
 import os
 import fileinput
 
+# this has to be a magic number, otherwise all .java files need to be
+# checked to see what the max line number is
 MAX_LINE_AMOUNT = 20000;
 
 # name of the file that is outputted

--- a/checkstylediff.py
+++ b/checkstylediff.py
@@ -56,16 +56,19 @@ def suppressfile(file, changes):
 		lines = 'lines="'+lines+'"'
 	return start +" "+ files +" "+ lines +"/>"
 	
+currentfile = ""
 # the program takes the piped input and processes it line for line
 for line in sys.stdin:
 	# the current file the changes are in
-	if re.findall("diff --git", line):
+	checkfile = re.findall("\sb/.*\\n", line)
+	if re.findall("diff --git", line) and checkfile and re.findall("\.java", checkfile[0]):
 		# when the first file is found
 		if not currentfile:
 			# the changed file name
-			currentfile = re.findall("\sb/.*\s", line)[0].replace(" b/","").replace(" ","").replace("\n","")
+			currentfile = re.findall("\sb/.*\\n", line)[0].replace(" b/","").replace(" ","").replace("\n","")
 		# the changed file name
-		newfile = re.findall("\sb/.*\s", line)[0].replace(" b/","").replace(" ","").replace("\n","")
+		print(line)
+		newfile = re.findall("\sb/.*\\n", line)[0].replace(" b/","").replace(" ","").replace("\n","")
 		# if these are not equal then git diff is talking about a different file and the registered changes have to be put in
 		# the list
 		if(newfile != currentfile):
@@ -78,7 +81,8 @@ for line in sys.stdin:
 		changes_in_file.append([int(x) for x in changed.replace("+","").split(",")])
 
 # when finished add the last file changes in the list
-changed_files.append((currentfile,changes_in_file))
+if currentfile:
+	changed_files.append((currentfile,changes_in_file))
 
 
 java_files = []

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -172,7 +172,6 @@
 					<forceMojoExecution>false</forceMojoExecution>
 					<check>
                         <totalLineRate>75</totalLineRate>
-                        <totalBranchRate>75</totalBranchRate>
                         <haltOnFailure>true</haltOnFailure>
 					</check>
 				</configuration>

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -211,17 +211,6 @@
                         </plugin>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <version>2.10.3</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-report-plugin</artifactId>
-                            <version>2.18.1</version>
-                        </plugin>
-           
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-pmd-plugin</artifactId>
                             <version>3.5</version>
                         </plugin>

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -193,8 +193,41 @@
 					</execution>
 				</executions>
 			</plugin>
-
-
+			
+			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <configuration>
+                    <reportPlugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-project-info-reports-plugin</artifactId>
+                            <version>2.8.1</version>
+                            <configuration>
+                                <dependencyDetailsEnabled>true</dependencyDetailsEnabled>
+                                <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <version>2.10.3</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-report-plugin</artifactId>
+                            <version>2.18.1</version>
+                        </plugin>
+           
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-pmd-plugin</artifactId>
+                            <version>3.5</version>
+                        </plugin>
+                    </reportPlugins>
+                </configuration>
+            </plugin>
 
 		</plugins>
 	</build>

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -220,5 +220,15 @@
 
 		</plugins>
 	</build>
+	
+	<reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.6</version>
+      </plugin>
+    </plugins>
+  </reporting>
 
 </project>

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -154,6 +154,32 @@
 					<altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
 				</configuration>
 			</plugin>
+			
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.7</version>
+				<configuration>
+				         <formats>
+            <format>xml</format>
+            <format>html</format>
+          </formats>
+					<forceMojoExecution>false</forceMojoExecution>
+					<check>
+                        <lineRate>75</lineRate>
+                        <haltOnFailure>true</haltOnFailure>
+					</check>
+				</configuration>
+				<executions>
+				<execution>
+					<phase>verify</phase>
+					<goals>
+					<goal>clean</goal>
+					<goal>check</goal>
+					</goals>
+				</execution>
+				</executions>
+			</plugin>
 
 			<plugin>
 				<groupId>com.github.github</groupId>
@@ -193,5 +219,4 @@
 
 		</plugins>
 	</build>
-
 </project>

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -171,8 +171,9 @@
           </formats>
 					<forceMojoExecution>false</forceMojoExecution>
 					<check>
-                        <lineRate>75</lineRate>
-                        <haltOnFailure>false</haltOnFailure>
+                        <totalLineRate>75</totalLineRate>
+                        <totalBranchRate>75</totalBranchRate>
+                        <haltOnFailure>true</haltOnFailure>
 					</check>
 				</configuration>
 				<executions>

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -228,6 +228,14 @@
         <artifactId>maven-pmd-plugin</artifactId>
         <version>3.6</version>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.4-SNAPSHOT</version>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+        </configuration>
+      </plugin>
     </plugins>
   </reporting>
 

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -172,7 +172,7 @@
 					<forceMojoExecution>false</forceMojoExecution>
 					<check>
                         <lineRate>75</lineRate>
-                        <haltOnFailure>true</haltOnFailure>
+                        <haltOnFailure>false</haltOnFailure>
 					</check>
 				</configuration>
 				<executions>

--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -80,6 +80,11 @@
 			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-pmd-plugin</artifactId>
+			<version>3.6</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/environment/src/main/java/tygronenv/connection/cool.java
+++ b/environment/src/main/java/tygronenv/connection/cool.java
@@ -1,0 +1,5 @@
+package tygronenv.connection;
+
+public class cool {
+
+}

--- a/environment/src/main/java/tygronenv/connection/cool.java
+++ b/environment/src/main/java/tygronenv/connection/cool.java
@@ -1,5 +1,0 @@
-package tygronenv.connection;
-
-public class cool {
-
-}

--- a/google_checks.xml
+++ b/google_checks.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html.
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+    To completely disable a check, just comment it out or delete it from the file.
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+	
+	
+ -->
+
+ <module name="SuppressionFilter">
+ <property name="file" value="suppression.xml"/>
+ </module>
+ 
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="warning"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="FileTabCharacter">
+            <property name="eachLine" value="true"/>
+        </module>
+
+    <module name="TreeWalker">
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Avoid using corresponding octal or Unicode escape."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly">
+            <property name="maxLineLength" value="100"/>
+        </module>
+        <module name="RightCurly"/>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+             <message key="ws.notPreceded"
+             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+            <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+             <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+             <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+             <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="2"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="2"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="2"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="specialImportsRegExp" value="com.google"/>
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="SummaryJavadoc">
+            <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,38 @@
 					<configLocation>google_checks.xml</configLocation>
 				</configuration>
 			</plugin>
+			
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.7</version>
+				<configuration>
+				<instrumentation>
+					<excludes>
+						<exclude>com/**/*.java</exclude>
+						<exclude>nl/**/*.java</exclude>
+					</excludes>
+				</instrumentation>
+					<check>
+					<lineRate>75</lineRate>
+					<haltOnFailure>true</haltOnFailure>
+
+					</check>
+					<formats>
+					<format>html</format>
+					<format>xml</format>
+					</formats>
+				</configuration>
+				<executions>
+				<execution>
+					<goals>
+					<goal>clean</goal>
+					<goal>check</goal>
+					</goals>
+				</execution>
+				</executions>
+			</plugin>
+			
 		
 		
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
+	
+	
 	<modules>
 		<module>sdk</module>
 		<module>sdk-tests</module>
@@ -23,6 +25,16 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.17</version>
+				<configuration>
+					<configLocation>google_checks.xml</configLocation>
+				</configuration>
+			</plugin>
+		
+		
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,39 +35,6 @@
 			</plugin>
 			
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-				<instrumentation>
-					<excludes>
-						<exclude>com/**/*.java</exclude>
-						<exclude>nl/**/*.java</exclude>
-					</excludes>
-				</instrumentation>
-					<check>
-					<lineRate>75</lineRate>
-					<haltOnFailure>true</haltOnFailure>
-
-					</check>
-					<formats>
-					<format>html</format>
-					<format>xml</format>
-					</formats>
-				</configuration>
-				<executions>
-				<execution>
-					<goals>
-					<goal>clean</goal>
-					<goal>check</goal>
-					</goals>
-				</execution>
-				</executions>
-			</plugin>
-			
-		
-		
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>2.8.2</version>


### PR DESCRIPTION
User Story: As a programmer I want to make informed decisions on the quality of a merge request by using Continuous integration.

Because the connector is mostly code not written or maintained by us, we'll only do checkstyle on the code that we touch. In this way we provide strong arguments that we can do checkstyle well (by example) while not running in constantly correct checkstyle mistakes from the repo we fork off. This would be an uphill battle.

The python script on the server is run by using jython. This is because Travis only supports one development language per integration.

Cobertura fails when the line coverage for the Environment for a file is lower than 75%. 

PMD and Findbugs are just outputted in the Travis Log.
