### PR TITLE
Removed old stakeholder percept and fixed corresponding test

### DIFF
--- a/environment/src/main/java/tygronenv/translators/J2Stakeholder.java
+++ b/environment/src/main/java/tygronenv/translators/J2Stakeholder.java
@@ -33,12 +33,8 @@ public class J2Stakeholder implements Java2Parameter<Stakeholder> {
      */
 	@Override
 	public Parameter[] translate(final Stakeholder stakeholder) throws TranslationException {
-	    List<Indicator> indicatorList = stakeholder.getMyIndicators();
-	    if (indicatorList.isEmpty()) {
-	        return new Parameter[] { new Identifier(stakeholder.getName()) };
-	    }
 		return new Parameter[] { new Function("indicatorLink", new Numeral(stakeholder.getID()), 
-		        indicator(indicatorList, stakeholder)) };
+		        indicator(stakeholder.getMyIndicators(), stakeholder)) };
 	}
 
 	/**

--- a/environment/src/test/java/tygronenv/TestEnvironmentStates.java
+++ b/environment/src/test/java/tygronenv/TestEnvironmentStates.java
@@ -74,7 +74,9 @@ public class TestEnvironmentStates {
 
 		LinkedList<Percept> percepts = env.getAllPerceptsFromEntity(ENTITY);
 		Percept expectedPercept = new Percept("stakeholders",
-				new ParameterList(new Parameter[] { new Identifier("Municipality"), new Identifier("Inhabitants") }));
+				new ParameterList(new Parameter[] { new Function("indicatorLink", new Numeral(0), 
+				        new ParameterList()), new Function("indicatorLink", new Numeral(1), 
+		                        new ParameterList()) }));
 		assertTrue(percepts.contains(expectedPercept));
 
 	}


### PR DESCRIPTION
User story: As a programmer I want to remove the unnecessary code of the old percept so that other programmers working with the stakeholder translator can add their code easier.  

Removed the old stakeholder percept for if there were no indicators in J2Stakeholder
Fixed the corresponding test in TestEnvironmentStates
