### PR TITLE
Fixed targetvalue of indicator percept

### DIFF
--- a/environment/src/main/java/tygronenv/translators/J2Indicator.java
+++ b/environment/src/main/java/tygronenv/translators/J2Indicator.java
@@ -32,11 +32,18 @@ public class J2Indicator implements Java2Parameter<Indicator> {
 		if (value == null) {
 			value = 0.0;
 		}
+		double[] targets = indicator.getTargets(1);
+		double target = 0.0;
+		if (targets == null || targets.length == 0) {
+		    target = indicator.getTarget();
+		} else {
+		    target = targets[0];
+		}
 		
 		return new Parameter[] {new Function("indicator",
 				new Numeral(indicator.getID()),
 				new Numeral(value),
-				new Numeral(indicator.getTarget()))};
+				new Numeral(target))};
 	}
 	
 	/**


### PR DESCRIPTION
As a programmer I want to remove bugs from the connector so that the bot can read the correct values from the environment.

Fixes indicator target value to get the actual target value instead of 0,0.
