### PR TITLE
Extended J2Land to include possible zones land is in and changed owner representation

### DIFF
--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -1,226 +1,241 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- name of the main project on eishub. -->
-		<environmentname>tygron</environmentname>
-		<mainclass>tygronenv.EisEnv</mainclass>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- name of the main project on eishub. -->
+        <environmentname>tygron</environmentname>
+        <mainclass>tygronenv.EisEnv</mainclass>
+        <powermock.version>1.6.5</powermock.version>
+    </properties>
 
-	<groupId>eishub</groupId>
-	<artifactId>tygronenv</artifactId>
-	<version>1.0.9</version>
-	<name>${environmentname}env</name>
-	<description>EIS-Tygron connector</description>
-	<url>http://www.github.com/eishub/${environmentname}</url>
+    <groupId>eishub</groupId>
+    <artifactId>tygronenv</artifactId>
+    <version>1.0.9</version>
+    <name>${environmentname}env</name>
+    <description>EIS-Tygron connector</description>
+    <url>http://www.github.com/eishub/${environmentname}</url>
 
-	<licenses>
-		<license>
-			<name>The GNU General Public License, Version 3.0</name>
-			<url>http://www.gnu.org/licenses/gpl-3.0.txt</url>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>The GNU General Public License, Version 3.0</name>
+            <url>http://www.gnu.org/licenses/gpl-3.0.txt</url>
+        </license>
+    </licenses>
 
-	<developers>
-		<developer>
-			<name>Koen Hindriks</name>
-			<email>k.v.hindriks@gmail.com</email>
-			<organization>eishub</organization>
-			<organizationUrl>https://github.com/koenhindriks</organizationUrl>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <name>Koen Hindriks</name>
+            <email>k.v.hindriks@gmail.com</email>
+            <organization>eishub</organization>
+            <organizationUrl>https://github.com/koenhindriks</organizationUrl>
+        </developer>
+    </developers>
 
-	<organization>
-		<name>eishub</name>
-		<url>https://github.com/eishub</url>
-	</organization>
+    <organization>
+        <name>eishub</name>
+        <url>https://github.com/eishub</url>
+    </organization>
 
-	<issueManagement>
-		<url>https://github.com/eishub/${environmentname}/issues</url>
-		<system>Github ${environmentname} Issues</system>
-	</issueManagement>
+    <issueManagement>
+        <url>https://github.com/eishub/${environmentname}/issues</url>
+        <system>Github ${environmentname} Issues</system>
+    </issueManagement>
 
-	<scm>
-		<connection>scm:git:git@github.com:eishub/${environmentname}.git</connection>
-		<developerConnection>scm:git:git@github.com:eishub/${environmentname}.git</developerConnection>
-		<url>https://github.com:eishub/${environmentname}</url>
-	</scm>
+    <scm>
+        <connection>scm:git:git@github.com:eishub/${environmentname}.git</connection>
+        <developerConnection>scm:git:git@github.com:eishub/${environmentname}.git</developerConnection>
+        <url>https://github.com:eishub/${environmentname}</url>
+    </scm>
 
-	<repositories>
-		<repository>
-			<id>eishub-mvn-repo</id>
-			<url>https://raw.github.com/eishub/mvn-repo/master</url>
-		</repository>
-	</repositories>
+    <repositories>
+        <repository>
+            <id>eishub-mvn-repo</id>
+            <url>https://raw.github.com/eishub/mvn-repo/master</url>
+        </repository>
+    </repositories>
+    
+    <dependencies>
+        <dependency>
+            <groupId>nl.tygron</groupId>
+            <artifactId>sdk</artifactId>
+            <version>2016.5.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>eishub</groupId>
+            <artifactId>eis</artifactId>
+            <version>0.5.0</version>
+        </dependency>
 
-	<dependencies>
-		<dependency>
-			<groupId>nl.tygron</groupId>
-			<artifactId>sdk</artifactId>
-			<version>2016.5.0.4</version>
-		</dependency>
-		<dependency>
-			<groupId>eishub</groupId>
-			<artifactId>eis</artifactId>
-			<version>0.5.0</version>
-		</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- http://mvnrepository.com/artifact/org.powermock/powermock-module-junit4 -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.powermock</groupId>
+          <artifactId>powermock-api-mockito</artifactId>
+          <version>1.6.5</version>
+          <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
+            <version>3.6</version>
+        </dependency>
+    </dependencies>
 
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-pmd-plugin</artifactId>
-			<version>3.6</version>
-		</dependency>
-	</dependencies>
+    <build>
+        <plugins>
+            <!-- running tygron sdk code (for the tests) requires java 1.8 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
 
-	<build>
-		<plugins>
-			<!-- running tygron sdk code (for the tests) requires java 1.8 -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.2</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>${mainclass}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attached</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.5.2</version>
-				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-					<archive>
-						<manifest>
-							<mainClass>${mainclass}</mainClass>
-						</manifest>
-					</archive>
-				</configuration>
-				<executions>
-					<execution>
-						<id>make-assembly</id>
-						<phase>package</phase>
-						<goals>
-							<goal>attached</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${mainclass}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<archive>
-						<manifest>
-							<mainClass>${mainclass}</mainClass>
-						</manifest>
-					</archive>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
-				<configuration>
-					<altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
-				</configuration>
-			</plugin>
-			
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-				         <formats>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <configuration>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+                </configuration>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                         <formats>
             <format>xml</format>
             <format>html</format>
           </formats>
-					<forceMojoExecution>false</forceMojoExecution>
-					<check>
+                    <forceMojoExecution>false</forceMojoExecution>
+                    <check>
                         <totalLineRate>75</totalLineRate>
                         <haltOnFailure>true</haltOnFailure>
-					</check>
-				</configuration>
-				<executions>
-				<execution>
-					<phase>verify</phase>
-					<goals>
-					<goal>clean</goal>
-					<goal>check</goal>
-					</goals>
-				</execution>
-				</executions>
-			</plugin>
+                    </check>
+                </configuration>
+                <executions>
+                <execution>
+                    <phase>verify</phase>
+                    <goals>
+                    <goal>clean</goal>
+                    <goal>check</goal>
+                    </goals>
+                </execution>
+                </executions>
+            </plugin>
 
-			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<version>0.12</version>
-				<configuration>
-					<server>github</server>
-					<!-- git commit message -->
-					<message>Maven artifacts for ${project.name} version
-						${project.version}</message>
-					<!-- matches distribution management repository url above -->
-					<outputDirectory>${project.build.directory}/mvn-repo</outputDirectory>
-					<!-- remote branch name -->
-					<branch>refs/heads/master</branch>
-					<merge>true</merge>
-					<includes>
-						<include>**/*</include>
-					</includes>
-					<!-- github repo name -->
-					<repositoryName>mvn-repo</repositoryName>
-					<!-- github organization -->
-					<repositoryOwner>eishub</repositoryOwner>
-				</configuration>
-				<executions>
-					<!-- run site-maven-plugin as part of the build's 'deploy' phase -->
-					<execution>
-						<id>git-deploy</id>
-						<goals>
-							<goal>site</goal>
-						</goals>
-						<phase>deploy</phase>
-					</execution>
-				</executions>
-			</plugin>
-			
-			<plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.12</version>
+                <configuration>
+                    <server>github</server>
+                    <!-- git commit message -->
+                    <message>Maven artifacts for ${project.name} version
+                        ${project.version}</message>
+                    <!-- matches distribution management repository url above -->
+                    <outputDirectory>${project.build.directory}/mvn-repo</outputDirectory>
+                    <!-- remote branch name -->
+                    <branch>refs/heads/master</branch>
+                    <merge>true</merge>
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
+                    <!-- github repo name -->
+                    <repositoryName>mvn-repo</repositoryName>
+                    <!-- github organization -->
+                    <repositoryOwner>eishub</repositoryOwner>
+                </configuration>
+                <executions>
+                    <!-- run site-maven-plugin as part of the build's 'deploy' phase -->
+                    <execution>
+                        <id>git-deploy</id>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.4</version>
@@ -244,10 +259,10 @@
                 </configuration>
             </plugin>
 
-		</plugins>
-	</build>
-	
-	<reporting>
+        </plugins>
+    </build>
+    
+    <reporting>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/environment/src/main/java/tygronenv/translators/J2Land.java
+++ b/environment/src/main/java/tygronenv/translators/J2Land.java
@@ -6,23 +6,33 @@ import eis.eis2java.translation.Translator;
 import eis.iilang.Function;
 import eis.iilang.Numeral;
 import eis.iilang.Parameter;
+import eis.iilang.ParameterList;
+import nl.tytech.core.client.event.EventManager;
+import nl.tytech.core.net.serializable.MapLink;
+import nl.tytech.core.structure.ItemMap;
 import nl.tytech.data.engine.item.Land;
+import nl.tytech.data.engine.item.Zone;
 
 /**
- * Translate {@link Land} into land(id,name, owner, poly).
- * 
- * @author W.Pasman
- *
+ * Translate {@link Land} into land(ID,OwnerID,MultiPolygon,ZonesList).
+ * @author W.Pasman & Nick Cleintuar & Diony Tadema (DaNSHaL).
  */
 public class J2Land implements Java2Parameter<Land> {
 
 	private final Translator translator = Translator.getInstance();
 
 	@Override
-	public Parameter[] translate(Land b) throws TranslationException {
+	public Parameter[] translate(final Land land) throws TranslationException {
+		ParameterList parList = new ParameterList();
+		ItemMap<Zone> zones = EventManager.<Zone>getItemMap(MapLink.ZONES);
+		for (Zone zone : zones.values()) {
+			if (zone.getMultiPolygon().intersects(land.getMultiPolygon())) {
+				parList.add(new Numeral(zone.getID()));
+			}
+		}
 		return new Parameter[] {
-				new Function("land", new Numeral(b.getID()), translator.translate2Parameter(b.getOwner())[0],
-						translator.translate2Parameter(b.getMultiPolygon())[0]) };
+				new Function("land", new Numeral(land.getID()), new Numeral(land.getOwnerID()),
+						translator.translate2Parameter(land.getMultiPolygon())[0], parList) };
 	}
 
 	@Override

--- a/environment/src/test/java/tygronenv/translators/J2LandTest.java
+++ b/environment/src/test/java/tygronenv/translators/J2LandTest.java
@@ -1,0 +1,87 @@
+package tygronenv.translators;
+
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vividsolutions.jts.geom.MultiPolygon;
+
+import eis.eis2java.exception.TranslationException;
+import eis.eis2java.translation.Translator;
+import eis.iilang.Function;
+import nl.tytech.core.client.event.EventManager;
+import nl.tytech.core.net.serializable.MapLink;
+import nl.tytech.core.structure.ItemMap;
+import nl.tytech.data.engine.item.Land;
+import nl.tytech.data.engine.item.Zone;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.LinkedList;
+
+/**
+ * Class which contains tests for the J2Land.java class.
+ * @author Nick Cleintuar & Hao Ming Yeh(DaNSHaL).
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({EventManager.class, Land.class, Zone.class})
+public class J2LandTest {
+
+	/**
+     * Translator for the Land class.
+	 */
+	private J2Land translator;
+
+	/**
+	 * Field for object Land which is used as mock.
+	 */
+	private Land land;
+
+	/**
+	 * Field for object Zone which is used as mock.
+	 */
+	private Zone zone;
+
+	/**
+	 * Initialization method called before every test.
+	 */
+	@SuppressWarnings("unchecked")
+	@Before
+	public void init() {
+		translator = new J2Land();
+		land = PowerMockito.mock(Land.class);
+		zone = PowerMockito.mock(Zone.class);
+		MultiPolygon mp = mock(MultiPolygon.class);
+		J2MultiPolygon j2mp = new J2MultiPolygon();
+		Translator.getInstance().registerJava2ParameterTranslator(j2mp);
+		ItemMap<Zone> map = (ItemMap<Zone>) mock(ItemMap.class);
+		LinkedList<Zone> list = new LinkedList<Zone>();
+		when(map.values()).thenReturn(list);
+		PowerMockito.mockStatic(EventManager.class);
+		PowerMockito.when(EventManager.<Zone>getItemMap(MapLink.ZONES)).thenReturn(map);
+		PowerMockito.when(land.getMultiPolygon()).thenReturn(mp);
+		PowerMockito.when(zone.getMultiPolygon()).thenReturn(mp);
+		PowerMockito.when(land.getOwnerID()).thenReturn(0);
+		PowerMockito.when(land.getID()).thenReturn(0);
+		PowerMockito.when(zone.getID()).thenReturn(0);
+	}
+
+	/**
+	 * Test method which verifies that methods that are called.
+	 * @throws TranslationException
+	 *             thrown if translating fails.
+	 */
+	@Test
+	public void testTranslate() throws TranslationException {
+		Function function = (Function) translator.translate(land)[0];
+		verify(land, atLeast(1)).getOwnerID();
+		verify(land, atLeast(1)).getMultiPolygon();
+		verify(land, atLeast(1)).getID();
+	}
+}


### PR DESCRIPTION
User story: As a programmer, I want to know in which zones lands are, so I can complete my indicators per zone.
- For each land percept, it will now show in which zones it is. 
- The owner of the land was represented as a stakeholder predicate. This is now changed so it is the ID of the stakeholder directly. This means that you should infer from the stakeholder predicates which stakeholder the owner is.
- This means that land/3 is extended to land/4 as followed: `land/4 - land(<LandID>,<StakeholderID>,<MultiPolygon>,[<ZoneID>])
